### PR TITLE
fix(ci): add --no-sandbox to qunit puppeteer — fixes "No usable sandbox" CI failure

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,21 +1,5 @@
 ## Contributing
-Please keep the [issue tracker](https://github.com/hakimel/reveal.js/issues) limited to **bug reports**.
+If you want to contribute a deck to the repo, feel free to fork this repository, create a branch with a title that follows this format:
+`githubUsername/deckTitle`.
 
-
-### General Questions and Support
-If you have questions about how to use reveal.js the best place to ask is in the [Discussions](https://github.com/hakimel/reveal.js/discussions). Anything that isn't a bug report should be posted as a dicussion instead.
-
-
-### Bug Reports
-When reporting a bug make sure to include information about which browser and operating system you are on as well as the necessary steps to reproduce the issue. If possible please include a link to a sample presentation where the bug can be tested.
-
-
-### Pull Requests
-- Should be submitted from a feature/topic branch (not your master)
-- Should follow the coding style of the file you work in, most importantly:
-  - Tabs to indent
-  - Single-quoted strings
-
-
-### Plugins
-Please do not submit plugins as pull requests. They should be maintained in their own separate repository. More information here: https://github.com/hakimel/reveal.js/wiki/Plugin-Guidelines
+One you've created your deck, submit a PR to have it added.

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,0 @@
-github: [hakimel]

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
           node-version: ${{ matrix.node-version }}
 

--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-wyretechnology.com

--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+wyretechnology.com

--- a/README.md
+++ b/README.md
@@ -1,48 +1,29 @@
-<p align="center">
-  <a href="https://revealjs.com">
-  <img src="https://hakim-static.s3.amazonaws.com/reveal-js/logo/v1/reveal-black-text-sticker.png" alt="reveal.js" width="500">
-  </a>
-  <br><br>
-  <a href="https://github.com/hakimel/reveal.js/actions"><img src="https://github.com/hakimel/reveal.js/workflows/tests/badge.svg"></a>
-  <a href="https://slides.com/"><img src="https://s3.amazonaws.com/static.slid.es/images/slides-github-banner-320x40.png?1" alt="Slides" width="160" height="20"></a>
-</p>
-
+# WYRE Technology reveal.js decks
+## About reveal.js
 reveal.js is an open source HTML presentation framework. It enables anyone with a web browser to create beautiful presentations for free. Check out the live demo at [revealjs.com](https://revealjs.com/).
 
 The framework comes with a powerful feature set including [nested slides](https://revealjs.com/vertical-slides/), [Markdown support](https://revealjs.com/markdown/), [Auto-Animate](https://revealjs.com/auto-animate/), [PDF export](https://revealjs.com/pdf-export/), [speaker notes](https://revealjs.com/speaker-view/), [LaTeX typesetting](https://revealjs.com/math/), [syntax highlighted code](https://revealjs.com/code/) and an [extensive API](https://revealjs.com/api/).
 
----
+## Getting started
+Create a fork of this repository and clone it to your computer:
 
-Want to create reveal.js presentation in a graphical editor? Try <https://slides.com>. It's made by the same people behind reveal.js.
+```
+git clone https://github.com/YOUR_USERNAME/decks.git
+```
+Create a branch with your GitHub username and the title of your deck:
 
----
+```
+git checkout -b YOUR_USERNAME/deckTitle
+```
+Edit your slides in the `presentations` directory. You can use Markdown, HTML or a combination of both. When you're ready, commit your changes and push them to your fork:
 
-### Sponsors
-Hakim's open source work is supported by <a href="https://github.com/sponsors/hakimel">GitHub sponsors</a>. Special thanks to:
-<div align="center">
-  <table>
-    <td align="center">
-      <a href="https://workos.com/?utm_campaign=github_repo&utm_medium=referral&utm_content=revealjs&utm_source=github">
-        <div>
-          <img src="https://user-images.githubusercontent.com/629429/151508669-efb4c3b3-8fe3-45eb-8e47-e9510b5f0af1.svg" width="290" alt="WorkOS">
-        </div>
-        <b>Your app, enterprise-ready.</b>
-        <div>
-          <sub>Start selling to enterprise customers with just a few lines of code. Add Single Sign-On (and more) in minutes instead of months.</sup>
-        </div>
-      </a>
-    </td>
-  </table>
-</div>
-
----
-
-### Getting started
-- 🚀 [Install reveal.js](https://revealjs.com/installation)
-- 👀 [View the demo presentation](https://revealjs.com/demo)
-- 📖 [Read the documentation](https://revealjs.com/markup/)
-- 🖌 [Try the visual editor for reveal.js at Slides.com](https://slides.com/)
-- 🎬 [Watch the reveal.js video course (paid)](https://revealjs.com/course)
+```
+cd presentations
+git add .
+git commit -s -m 'Add my awesome slides'
+git push
+```
+Submit a pull request to have your deck added to the repository. Once your PR is merged, your slides will be available at `https://wyre-technology.github.io/decks/presentations/deckTitle`.
 
 --- 
 <div align="center">

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -211,7 +211,16 @@ gulp.task('qunit', () => {
                 targetUrl: `http://${serverConfig.host}:${serverConfig.port}/${filename}`,
                 timeout: 20000,
                 redirectConsole: false,
-                puppeteerArgs: ['--allow-file-access-from-files']
+                // --no-sandbox / --disable-setuid-sandbox: Chrome's SUID
+                // sandbox cannot initialize on the CI runner (root-in-
+                // container) — puppeteer fails with "FATAL: No usable
+                // sandbox!" and the qunit suite never runs. This is the
+                // CI/headless TEST launch only (running the qunit test
+                // pages in ephemeral CI against local test content), NOT a
+                // production/runtime browser path — so disabling the
+                // sandbox here is the standard, scoped CI fix the error
+                // message itself recommends.
+                puppeteerArgs: ['--allow-file-access-from-files', '--no-sandbox', '--disable-setuid-sandbox']
             })
                 .then(result => {
                     if( result.stats.failed > 0 ) {

--- a/index.html.orig
+++ b/index.html.orig
@@ -1,0 +1,40 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+
+		<title>reveal.js</title>
+
+		<link rel="stylesheet" href="dist/reset.css">
+		<link rel="stylesheet" href="dist/reveal.css">
+		<link rel="stylesheet" href="dist/theme/black.css">
+
+		<!-- Theme used for syntax highlighted code -->
+		<link rel="stylesheet" href="plugin/highlight/monokai.css">
+	</head>
+	<body>
+		<div class="reveal">
+			<div class="slides">
+				<section>Slide 1</section>
+				<section>Slide 2</section>
+			</div>
+		</div>
+
+		<script src="dist/reveal.js"></script>
+		<script src="plugin/notes/notes.js"></script>
+		<script src="plugin/markdown/markdown.js"></script>
+		<script src="plugin/highlight/highlight.js"></script>
+		<script>
+			// More info about initialization & config:
+			// - https://revealjs.com/initialization/
+			// - https://revealjs.com/config/
+			Reveal.initialize({
+				hash: true,
+
+				// Learn about plugins: https://revealjs.com/plugins/
+				plugins: [ RevealMarkdown, RevealHighlight, RevealNotes ]
+			});
+		</script>
+	</body>
+</html>

--- a/presentations/git-vscode-and-you.html
+++ b/presentations/git-vscode-and-you.html
@@ -101,9 +101,6 @@
                     <h3>Q&A</h3>
                 </section>
                 <section>
-                    <h3>THIS IS A CHANGE TO THE TIMELINE!!!!!!</h3>
-                </section>
-                <section>
                     <h3>Resources</h3>
                     <ul>
                         <li><a href="https://git-scm.com/">Git</a></li>

--- a/presentations/git-vscode-and-you.html
+++ b/presentations/git-vscode-and-you.html
@@ -46,9 +46,37 @@
                     <section>
                         <h3>How do I get it?</h3>
                     </section>
-                    <section>
-                        <h3>How do I use it?</h3>
+                    <section data-markdown>
+                        <textarea data-template>
+                            ### How do I use it?
+
+                            1. Initialize a repository 
+                            2. Write some code
+                            3. Stage your changes
+                            4. Commit your changes
+                            5. Push your changes
+                        </textarea>
                     </section>
+                    <section data-markdown>
+                        <textarea data-template>
+                            ### Example
+                            
+                            <pre>
+                                <code data-trim data-noescape>
+                                    git init
+
+                                    echo 'print("Hello world!")' > hello.py
+
+                                    git add . (the `.` here adds everything in the current directory)
+
+                                    git commit -m 'My cool Python code'
+
+                                    git push
+                                </code>
+                            </pre>
+                        </textarea>
+                    </section>
+
                 </section>
                 <section>
                     <section>

--- a/presentations/git-vscode-and-you.html
+++ b/presentations/git-vscode-and-you.html
@@ -101,6 +101,9 @@
                     <h3>Q&A</h3>
                 </section>
                 <section>
+                    <h3>THIS IS A CHANGE TO THE TIMELINE!!!!!!</h3>
+                </section>
+                <section>
                     <h3>Resources</h3>
                     <ul>
                         <li><a href="https://git-scm.com/">Git</a></li>

--- a/presentations/git-vscode-and-you.html
+++ b/presentations/git-vscode-and-you.html
@@ -1,0 +1,99 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<title>Git, VSCode and You</title>
+        <link rel="stylesheet" href="../dist/reset.css">
+		<link rel="stylesheet" href="../dist/reveal.css">
+		<link rel="stylesheet" href="../dist/theme/moon.css">
+        <link rel="stylesheet" href="../plugin/highlight/monokai.css">
+	</head>
+	<body>
+
+		<div class="reveal">
+			<div class="slides">
+
+				<section>
+                    <h2>Git, VSCode, and You</h2>
+                    <h1>OR</h1>
+					<p>How I stopped worrying and learned to love source control</p>
+				</section>
+				<section>
+                    <section>
+                        <h2>Why this lunch & learn?</h2>
+                    </section>
+                    <section>
+                        <h3>The people have spoken...</h2>
+                        <iframe src="https://giphy.com/embed/l2JeaT1nX301ntHuE" width="480" height="360" frameBorder="0" class="giphy-embed" allowFullScreen></iframe><p><a href="https://giphy.com/gifs/season-12-the-simpsons-12x1-l2JeaT1nX301ntHuE"></a></p>    
+                    </section>
+                    <section>
+                        <h3>We actually write quite a bit of scripts/code</h3>
+                        <iframe src="https://giphy.com/embed/o0vwzuFwCGAFO" width="480" height="480" frameBorder="0" class="giphy-embed" allowFullScreen></iframe><p><a href="https://giphy.com/gifs/cat-hacker-webs-o0vwzuFwCGAFO"></a></p>
+                    </section>
+                    <section>
+                        <h3>We need some place to store that code</h3>
+                        <iframe src="https://giphy.com/embed/6WBWYpSlaLogKrn6RC" width="480" height="320" frameBorder="0" class="giphy-embed" allowFullScreen></iframe><p><a href="https://giphy.com/gifs/canadianmuseumofhistory-archivesgif-archaeology-cmhgif-6WBWYpSlaLogKrn6RC"></a></p>
+                    </section>
+				</section>
+                <section>
+                    <section>
+                    <h3>Git</h3>
+                    <img data-src="https://git-scm.com/images/logos/downloads/Git-Icon-1788C.png" width="200" height="200" alt="Git Logo" />
+                    </section>
+                    <section>
+                        <h3>What is it?</h3>
+                    </section>
+                    <section>
+                        <h3>How do I get it?</h3>
+                    </section>
+                    <section>
+                        <h3>How do I use it?</h3>
+                    </section>
+                </section>
+                <section>
+                    <section>
+                        <h3>VSCode</h3>
+                        <img data-src="https://code.visualstudio.com/assets/favicon.ico" width="200" height="200" alt="VSCode Logo" />
+                    </section>
+                    <section>
+                        <h3>What is it?</h3>
+                    </section>
+                    <section>
+                        <h3>How do I get it?</h3>
+                    </section>
+                    <section>
+                        <h3>How do I use it?</h3>
+                    </section>
+                </section>
+                <section>
+                    <h3>Live demo time!</h3>
+                    <div class="tenor-gif-embed" data-postid="24819060" data-share-method="host" data-aspect-ratio="1.46789" data-width="100%"><a href="https://tenor.com/view/bill-oreilly-well-do-it-live-we-will-inside-edition-the-oreilly-factor-gif-24819060">Bill Oreilly Well Do It Live GIF</a>from <a href="https://tenor.com/search/bill+oreilly-gifs">Bill Oreilly GIFs</a></div> <script type="text/javascript" async src="https://tenor.com/embed.js"></script>
+                </section>
+                <section>
+                    <h3>Q&A</h3>
+                </section>
+                <section>
+                    <h3>Resources</h3>
+                    <ul>
+                        <li><a href="https://git-scm.com/">Git</a></li>
+                        <li><a href="https://code.visualstudio.com/">VSCode</a></li>
+                        <li><a href="https://docs.github.com/en/get-started/start-your-journey/git-and-github-learning-resources">Github Learning</a></li>
+                    </ul>
+                </section>
+			</div>
+		</div>
+
+        <script src="../dist/reveal.js"></script>
+		<script src="../plugin/notes/notes.js"></script>
+		<script src="../plugin/markdown/markdown.js"></script>
+		<script src="../plugin/highlight/highlight.js"></script>
+		<script>
+			Reveal.initialize({
+				hash: true,
+
+				plugins: [ RevealMarkdown, RevealHighlight, RevealNotes ]
+			});
+		</script>
+
+	</body>
+</html>


### PR DESCRIPTION
## Repo-health: greens build (Node 18/20) (unblocks decks dependabot security-fixes)

CI was RED, blocking the dependabot security-fix PRs (qs/lodash/postcss/etc). **Grounded from real CI logs** — NOT the dep bumps:
```
FATAL:zygote_host_impl_linux.cc(127)] No usable sandbox! ... you can try using --no-sandbox.
```
Chrome's SUID sandbox can't initialize on the CI runner (root-in-container Linux) → puppeteer never launches → the qunit suite errors → exit 1. (Same dep-bump-is-a-red-herring meta as the autotask/grafana/brain-mcp sweep.)

## Fix

Add `--no-sandbox` + `--disable-setuid-sandbox` to the qunit `puppeteerArgs` (`gulpfile.js`) — the fix the FATAL error itself prescribes. This is the **CI/headless test launch only** (node-qunit-puppeteer running the qunit pages against local test content on an ephemeral runner), **not a production/runtime browser path** — decks is a presentations repo; puppeteer runs solely to execute the test suite. So the sandbox-disable is correctly scoped to CI-test.

## Verification caveat (honest)

The failure is **Linux-CI-runner-specific** ("No usable sandbox" = root-in-container) and does **not** reproduce on local macOS. The local qunit suite also can't run on Node 26 (pinned puppeteer-19 / `@puppeteer/browsers` chokes on Node 26's ESM scope — unrelated to this change). `gulpfile.js` syntax validated (`node -c`). **The real verification is this PR's CI on the Node 18/20 runners** — same replication-limit shape as a docker-daemon-down local. The fix is grounded: the error prescribes exactly this flag + it's the standard CI-puppeteer-sandbox fix.

Unblocks decks's dependabot security-fix bumps once CI greens.